### PR TITLE
Add a new configuration variable: g:lens#disabled_buftypes.

### DIFF
--- a/doc/lens.txt
+++ b/doc/lens.txt
@@ -19,6 +19,7 @@ USAGE.............................................................|lens-usage|
 CONFIGURATION.............................................|lens-configuration|
     g:lens#disabled..........................................|g:lens#disabled|
     g:lens#disabled_filetypes......................|g:lens#disabled_filetypes|
+    g:lens#disabled_buftypes........................|g:lens#disabled_buftypes|
     g:lens#animate............................................|g:lens#animate|
     g:lens#height_resize_max........................|g:lens#height_resize_max|
     g:lens#height_resize_min........................|g:lens#height_resize_min|
@@ -60,6 +61,13 @@ g:lens#disabled_filetypes
              Disables the plugin for the specified filetypes.
 
              Default value is [].
+
+                                                   *g:lens#disabled_buftypes*
+g:lens#disabled_buftypes
+             Disables the plugin for the specified buftypes.
+
+             Default value is [].
+                                                              *g:lens#animate*
                                                               *g:lens#animate*
 g:lens#animate
              If value is 1 and animate.vim is installed, the window resize

--- a/plugin/lens.vim
+++ b/plugin/lens.vim
@@ -56,6 +56,11 @@ if ! exists('g:lens#disabled_filetypes')
   let g:lens#disabled_filetypes = []
 endif
 
+if ! exists('g:lens#disabled_buftypes')
+  " Disable for the following buftypes
+  let g:lens#disabled_buftypes = []
+endif
+
 ""
 " Toggles the plugin on and off
 function! lens#toggle() abort
@@ -142,6 +147,10 @@ function! lens#win_enter() abort
 
   if index(g:lens#disabled_filetypes, &filetype) != -1
     return
+  endif
+
+  if index(g:lens#disabled_buftypes, &buftype != -1)
+      return
   endif
 
   call lens#run()

--- a/plugin/lens.vim
+++ b/plugin/lens.vim
@@ -149,7 +149,7 @@ function! lens#win_enter() abort
     return
   endif
 
-  if index(g:lens#disabled_buftypes, &buftype != -1)
+  if index(g:lens#disabled_buftypes, &buftype) != -1
       return
   endif
 


### PR DESCRIPTION
Like g:lens#disabled_filetypes it will allow the user to disable
the resizing of a window on specific buffer types.