### PR TITLE
add g:lens#disabled_filenames

### DIFF
--- a/doc/lens.txt
+++ b/doc/lens.txt
@@ -20,6 +20,7 @@ CONFIGURATION.............................................|lens-configuration|
     g:lens#disabled..........................................|g:lens#disabled|
     g:lens#disabled_filetypes......................|g:lens#disabled_filetypes|
     g:lens#disabled_buftypes........................|g:lens#disabled_buftypes|
+    g:lens#disabled_filenames......................|g:lens#disabled_filenames|
     g:lens#animate............................................|g:lens#animate|
     g:lens#height_resize_max........................|g:lens#height_resize_max|
     g:lens#height_resize_min........................|g:lens#height_resize_min|
@@ -65,6 +66,13 @@ g:lens#disabled_filetypes
                                                    *g:lens#disabled_buftypes*
 g:lens#disabled_buftypes
              Disables the plugin for the specified buftypes.
+
+             Default value is [].
+
+                                                   *g:lens#disabled_filenames*
+g:lens#disabled_filenames
+             Disables the plugin for the specified filenames using regular
+             expressions.
 
              Default value is [].
                                                               *g:lens#animate*

--- a/plugin/lens.vim
+++ b/plugin/lens.vim
@@ -61,6 +61,11 @@ if ! exists('g:lens#disabled_buftypes')
   let g:lens#disabled_buftypes = []
 endif
 
+if ! exists('g:lens#disabled_filenames')
+  " Disable for the following filenames
+  let g:lens#disabled_filenames = []
+endif
+
 ""
 " Toggles the plugin on and off
 function! lens#toggle() abort
@@ -151,6 +156,15 @@ function! lens#win_enter() abort
 
   if index(g:lens#disabled_buftypes, &buftype) != -1
       return
+  endif
+
+  if len(g:lens#disabled_filenames) > 0
+      let l:filename = expand('%:p')
+      for l:pattern in g:lens#disabled_filenames
+          if match(l:filename, pattern)
+              return
+          endif
+      endfor
   endif
 
   call lens#run()


### PR DESCRIPTION
Some plugins don't expose any filetypes/buftypes, so only way is to check
filename, for example, coc.nvim opens 'preview' windows and specifies filename
as `coc://document`.